### PR TITLE
Feat/batch events

### DIFF
--- a/src/batchedSocketEvents.ts
+++ b/src/batchedSocketEvents.ts
@@ -1,0 +1,59 @@
+import { createQueue } from './queue';
+import { createEventBroker } from './socketAdapter/eventBroker';
+import { Socket } from './socketAdapter/socket';
+
+type GenericEvents = {
+	[key: string]: any;
+};
+
+export type GenericQueuedEvent<Events extends GenericEvents> = {
+	event: keyof Events;
+	data: Events[keyof Events];
+};
+
+export function createBatchedClient<Events extends GenericEvents>(
+	connection: Socket,
+	interval?: number
+) {
+	type QueuedEvent = GenericQueuedEvent<Events>;
+
+	const events = createEventBroker<QueuedEvent['data']>();
+
+	const queue = createQueue<QueuedEvent, QueuedEvent[]>({
+		batch(current, update) {
+			return [...current, update];
+		},
+		createState() {
+			return [];
+		},
+		flush(events) {
+			connection.send('data', { events });
+		},
+		updateInterval: interval,
+	});
+
+	connection.on('data', (data: { events: QueuedEvent[] }) => {
+		data?.events?.forEach((event) => {
+			events.notify(event.event as string, event.data);
+		});
+	});
+
+	return {
+		queue<K extends keyof Events>(event: K, data: Events[K]) {
+			queue({ event, data });
+		},
+		subscribe<K extends keyof Events>(
+			event: K,
+			callback: (data: Events[K]) => void
+		) {
+			events.addListener(event as string, callback as any);
+			return () => events.removeListener(event as string, callback as any);
+		},
+		unsubscribe<K extends keyof Events>(
+			event: K,
+			callback?: (data: Events[K]) => void
+		) {
+			events.removeListener(event as string, callback as any);
+		},
+	};
+}

--- a/src/batchedSocketEvents.ts
+++ b/src/batchedSocketEvents.ts
@@ -27,13 +27,13 @@ export function createBatchedClient<Events extends GenericEvents>(
 			return [];
 		},
 		flush(events) {
-			connection.send('data', { events });
+			connection.send('events', events);
 		},
 		updateInterval: interval,
 	});
 
-	connection.on('data', (data: { events: QueuedEvent[] }) => {
-		data?.events?.forEach((event) => {
+	connection.on('events', (socketEvents: QueuedEvent[]) => {
+		socketEvents?.forEach((event) => {
 			events.notify(event.event as string, event.data);
 		});
 	});

--- a/src/client.ts
+++ b/src/client.ts
@@ -79,6 +79,9 @@ export function SocketDBClient<Schema extends SchemaDefinition = any>({
 	updateInterval?: number;
 	plugins?: ClientPlugin[];
 } = {}): SocketDBClientAPI<Schema> {
+	// use half of the update interval, because we have two update queues resulting in double the time
+	updateInterval = updateInterval / 2;
+
 	let url: string =
 		_url ||
 		(typeof window !== 'undefined'

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,33 @@
+export type Queue<T> = (data: T) => void;
+
+export function createQueue<QueuedData, BatchedData>({
+	batch,
+	createState,
+	flush,
+	updateInterval,
+}: {
+	createState: () => BatchedData;
+	batch: (current: BatchedData, update: QueuedData) => BatchedData;
+	flush: (batchedData: BatchedData) => void;
+	updateInterval?: number;
+}): Queue<QueuedData> {
+	if (!updateInterval)
+		return (update) => {
+			flush(batch(createState(), update));
+		};
+
+	let current = createState();
+	let pendingUpdate: ReturnType<typeof setTimeout> | null = null;
+
+	return (update) => {
+		if (!pendingUpdate) {
+			current = createState();
+			pendingUpdate = setTimeout(() => {
+				pendingUpdate = null;
+				flush(current);
+			}, updateInterval);
+		}
+
+		current = batch(current, update);
+	};
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,6 +69,9 @@ export function SocketDBServer({
 	socketServer?: SocketServer;
 	plugins?: ServerPlugin[];
 } = {}): SocketDBServerAPI {
+	// use half of the update interval, because we have two update queues resulting in double the time
+	updateInterval = updateInterval / 2;
+
 	let subscriber: Subscriptions = {};
 
 	const api: SocketDBServerAPI = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { createHooks, Hook } from 'krog';
+import { createBatchedClient } from './batchedSocketEvents';
 import { Node, traverseNode } from './node';
 import { joinPath } from './path';
 import { Plugin } from './plugin';
@@ -174,8 +175,9 @@ export function SocketDBServer({
 		}
 	}
 
-	socketServer.onConnection((client, id, context = {}) => {
+	socketServer.onConnection((connection, id, context = {}) => {
 		const clientContext = { id, context };
+		const socketEvents = createBatchedClient(connection, updateInterval);
 		hooks.call(
 			'server:clientConnect',
 			{
@@ -185,7 +187,7 @@ export function SocketDBServer({
 			{ asRef: true }
 		);
 
-		client.onDisconnect(() => {
+		connection.onDisconnect(() => {
 			delete subscriber[id];
 			delete subscriber[id + 'wildcard']; // this should be handled in a cleaner way
 			hooks.call(
@@ -194,34 +196,39 @@ export function SocketDBServer({
 				{ asRef: true }
 			);
 		});
-		client.on('update', ({ data }: { data: BatchedUpdate }) => {
+		socketEvents.subscribe('update', ({ data }: { data: BatchedUpdate }) => {
 			data.delete?.forEach((path) => del(path, clientContext));
 			if (data.change) update(data.change, clientContext);
 		});
-		client.on('subscribe', ({ path, once }) => {
-			client.send(path, { data: { change: store.get(path) } });
+		socketEvents.subscribe('subscribe', ({ path, once }) => {
+			socketEvents.queue(path, {
+				// deepClone to only send the current snapshot, as data might change while queued
+				data: { change: deepClone(store.get(path)) },
+			});
 			if (once) return;
 			addSubscriber(id, path, (data) => {
-				client.send(path, { data });
+				socketEvents.queue(path, { data });
 			});
 		});
-		client.on('unsubscribe', ({ path }) => {
+		socketEvents.subscribe('unsubscribe', ({ path }) => {
 			removeSubscriber(id, path);
 		});
-		client.on('subscribeKeys', ({ path }) => {
+		socketEvents.subscribe('subscribeKeys', ({ path }) => {
 			const data = store.get(path);
 			const wildcardPath = joinPath(path, '*');
 			let keys: string[] = [];
 			if (isObject(data.value)) {
 				keys = Object.keys(data.value);
-				client.send(wildcardPath, { data: keys });
+				// destructure keys to only send the current keys, as they might change while queued
+				socketEvents.queue(wildcardPath, { data: [...keys] });
 			}
 			addSubscriber(id + 'wildcard', path, (data: BatchedUpdate) => {
 				if (data.change && isObject(data.change.value)) {
 					const newKeys = Object.keys(data.change.value).filter(
 						(key) => !keys.includes(key)
 					);
-					if (newKeys.length > 0) client.send(wildcardPath, { data: newKeys });
+					if (newKeys.length > 0)
+						socketEvents.queue(wildcardPath, { data: newKeys });
 					keys = [...keys, ...newKeys];
 				}
 			});

--- a/src/updateBatcher.ts
+++ b/src/updateBatcher.ts
@@ -1,8 +1,7 @@
 import { Node } from './node';
-import { createStore } from './store';
+import { createQueue } from './queue';
+import { createStore, Store } from './store';
 import { isObject } from './utils';
-
-type Queue = (update: Change | Deletion) => void;
 
 export type BatchedUpdate = {
 	delete?: string[];
@@ -20,42 +19,36 @@ type Deletion = {
 };
 
 export function createUpdateBatcher(
-	flush: (batchedUpdate: BatchedUpdate) => void,
+	flushUpdate: (batchedUpdate: BatchedUpdate) => void,
 	updateInterval: number
-): Queue {
-	if (!updateInterval)
-		return (update) => {
+) {
+	return createQueue<
+		Change | Deletion,
+		{ diff: Store; deletions: Set<string> }
+	>({
+		createState() {
+			return {
+				deletions: new Set(),
+				diff: createStore(),
+			};
+		},
+		batch(current, update) {
 			if (update.type === 'delete') {
-				flush({ delete: [update.path] });
+				current.diff.del(update.path);
+				current.deletions.add(update.path);
 			} else if (update.type === 'change') {
-				flush({ change: update.data });
+				current.diff.put(update.data);
 			}
-		};
-
-	let diff = createStore();
-	let deletions: Set<string> = new Set();
-	let pendingUpdate: NodeJS.Timeout | null = null;
-
-	return (update: Change | Deletion) => {
-		if (!pendingUpdate) {
-			diff = createStore();
-			deletions = new Set();
-			pendingUpdate = setTimeout(() => {
-				pendingUpdate = null;
-				const update: BatchedUpdate = {};
-				if (deletions.size > 0) update.delete = Array.from(deletions);
-				const node = diff.get();
-				if (isObject(node.value) && Object.keys(node.value).length > 0)
-					update.change = node;
-				flush(update);
-			}, updateInterval);
-		}
-
-		if (update.type === 'delete') {
-			diff.del(update.path);
-			deletions.add(update.path);
-		} else if (update.type === 'change') {
-			diff.put(update.data);
-		}
-	};
+			return current;
+		},
+		flush({ deletions, diff }) {
+			const update: BatchedUpdate = {};
+			if (deletions.size > 0) update.delete = Array.from(deletions);
+			const node = diff.get();
+			if (isObject(node.value) && Object.keys(node.value).length > 0)
+				update.change = node;
+			flushUpdate(update);
+		},
+		updateInterval,
+	});
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -301,9 +301,9 @@ test('should batch subscribe events', (done) => {
 		onDisconnect() {},
 		off() {},
 		on() {},
-		send(event, { events }) {
+		send(event, events) {
 			// should batch all events in a single array
-			expect(event).toEqual('data');
+			expect(event).toEqual('events');
 			expect(events).toHaveLength(5);
 
 			sendCount++;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -259,7 +259,7 @@ test('can unsubscribe from path', (done) => {
 		expect(unsubscribeCount).toBe(1);
 		expect(updateCount).toBe(1);
 		done();
-	}, 100);
+	}, 50);
 });
 
 test('can subscribe to path once', (done) => {
@@ -272,7 +272,7 @@ test('can subscribe to path once', (done) => {
 		},
 	});
 
-	const client = SocketDBClient({ socketClient });
+	const client = SocketDBClient({ socketClient, updateInterval: 5 });
 
 	let updateCount = 0;
 	client
@@ -287,7 +287,7 @@ test('can subscribe to path once', (done) => {
 	setTimeout(() => {
 		expect(updateCount).toBe(1);
 		done();
-	}, 100);
+	}, 50);
 });
 
 test('should batch subscribe events', (done) => {
@@ -430,7 +430,7 @@ test('can unsubscribe from keys of path', (done) => {
 		},
 	});
 
-	const client = SocketDBClient({ socketClient });
+	const client = SocketDBClient({ socketClient, updateInterval: 5 });
 
 	let updateCount = 0;
 	const unsubscribe = client.get('players').each((ref) => {
@@ -440,9 +440,11 @@ test('can unsubscribe from keys of path', (done) => {
 	setTimeout(() => {
 		unsubscribe();
 		notify('players/*', { data: ['2', '3'] });
-		expect(updateCount).toBe(1);
-		done();
-	}, 100);
+		setTimeout(() => {
+			expect(updateCount).toBe(1);
+			done();
+		}, 50);
+	}, 50);
 });
 
 test('received data should not be passed as reference', (done) => {
@@ -558,7 +560,7 @@ test('only subscribes once for every root path', (done) => {
 		},
 	});
 
-	const client = SocketDBClient({ socketClient });
+	const client = SocketDBClient({ socketClient, updateInterval: 10 });
 
 	let subscriptionCount = 0;
 	let updateCount = 0;
@@ -592,8 +594,8 @@ test('only subscribes once for every root path', (done) => {
 		setTimeout(() => {
 			expect(updateCount).toBe(4);
 			done();
-		}, 100);
-	}, 100);
+		}, 50);
+	}, 50);
 });
 
 test('always subscribe to highest level path', (done) => {
@@ -610,7 +612,7 @@ test('always subscribe to highest level path', (done) => {
 		},
 	});
 
-	const client = SocketDBClient({ socketClient });
+	const client = SocketDBClient({ socketClient, updateInterval: 5 });
 
 	let subscriptionCount = 0;
 	let unsubscriptionCount = 0;
@@ -693,7 +695,7 @@ test('always subscribe to highest level path', (done) => {
 		expect(subscriptionCount).toBe(5);
 		expect(updateReceivedCount).toBe(3);
 		done();
-	}, 100);
+	}, 50);
 });
 
 test('does not resubscribe to keys if higher level path is already subscribed', (done) => {
@@ -740,7 +742,7 @@ test('if data is null, should notify every subpath', (done) => {
 		},
 	});
 
-	const client = SocketDBClient({ socketClient });
+	const client = SocketDBClient({ socketClient, updateInterval: 5 });
 
 	let subscriptionCount = 0;
 
@@ -778,7 +780,7 @@ test('if data is null, should notify every subpath', (done) => {
 		expect(testString).toBe('abcd');
 		expect(updateCount).toBe(4);
 		done();
-	}, 500);
+	}, 50);
 });
 
 test('subscribes again after reconnect', (done) => {

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -128,6 +128,8 @@ test('all clients receive data on update', async () => {
 });
 
 test('only sends data once for every update on same root path', (done) => {
+	let emitCount = 0;
+
 	const { connectClient, socketServer } = mockSocketServer();
 	const { notify: notifyClient, socketClient } = mockSocketClient({
 		onSend(event, data) {
@@ -136,7 +138,6 @@ test('only sends data once for every update on same root path', (done) => {
 		},
 	});
 
-	let emitCount = 0;
 	const client = SocketDBClient({ socketClient, updateInterval: 5 });
 	SocketDBServer({ socketServer, updateInterval: 5 });
 
@@ -161,7 +162,7 @@ test('only sends data once for every update on same root path', (done) => {
 	setTimeout(() => {
 		expect(emitCount).toBe(2);
 		done();
-	}, 100);
+	}, 50);
 });
 
 test('on/once always receives data on first call, even when not subscribed to before', (done) => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,10 +1,8 @@
 import { nodeify } from '../src/node';
 import { SocketDBServer } from '../src/server';
-import { createEventBroker } from '../src/socketAdapter/eventBroker';
-import { Socket } from '../src/socketAdapter/socket';
-import { SocketServer } from '../src/socketAdapter/socketServer';
 import { createStore } from '../src/store';
 import { BatchedUpdate } from '../src/updateBatcher';
+import { mockSocketServer } from './utils';
 
 test('updates data on manual update', () => {
 	const store = createStore();
@@ -28,27 +26,12 @@ test('updates data on manual update', () => {
 
 test('updates data on socket request', () => {
 	const store = createStore();
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, notify } = createEventBroker();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
+	const { socketServer, connectClient } = mockSocketServer();
+
 	SocketDBServer({ store, socketServer });
 
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off() {},
-			send() {},
-			close() {},
-		},
-		'1'
-	);
+	const { notify } = connectClient();
 	notify('update', {
 		data: {
 			change: nodeify({
@@ -69,27 +52,12 @@ test('updates data on socket request', () => {
 
 test('deletes data on socket request', (done) => {
 	const store = createStore();
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, notify } = createEventBroker();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
+	const { socketServer, connectClient } = mockSocketServer();
+
 	SocketDBServer({ store, socketServer });
 
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off() {},
-			send() {},
-			close() {},
-		},
-		'1'
-	);
+	const { notify } = connectClient();
 	notify('update', {
 		data: {
 			change: nodeify({
@@ -129,90 +97,62 @@ test('sends data on first subscribe', (done) => {
 		})
 	);
 
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, removeListener, notify } = createEventBroker();
+	const { socketServer, connectClient } = mockSocketServer();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
 	SocketDBServer({ store, socketServer });
 
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off: removeListener,
-			send(event, { data }) {
-				if (event === 'players/1') {
-					expect(data).toEqual({ change: nodeify({ name: 'Ralph' }) });
-					done();
-				}
-			},
-			close() {},
+	const { notify } = connectClient({
+		id: '1',
+		onSend(event, { data }) {
+			if (event === 'players/1') {
+				expect(data).toEqual({ change: nodeify({ name: 'Ralph' }) });
+				done();
+			}
 		},
-		'1'
-	);
+	});
 
 	notify('subscribe', { path: 'players/1' });
 });
 
 test('emits updates to subscriber', (done) => {
 	const store = createStore();
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, removeListener, notify } = createEventBroker();
+	const { socketServer, connectClient } = mockSocketServer();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
 	SocketDBServer({ store, socketServer });
 
 	let count = 1;
-
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off: removeListener,
-			send(event, { data }) {
-				if (event === 'players/1') {
-					if (count === 1) {
-						expect(data).toEqual({ change: nodeify(null) });
-						count++;
-						setTimeout(() => {
-							notify('update', {
-								data: {
-									change: nodeify({
-										players: {
-											1: {
-												name: 'Peter',
-											},
+	const { notify } = connectClient({
+		onSend(event, { data }) {
+			if (event === 'players/1') {
+				if (count === 1) {
+					expect(data).toEqual({ change: nodeify(null) });
+					count++;
+					setTimeout(() => {
+						notify('update', {
+							data: {
+								change: nodeify({
+									players: {
+										1: {
+											name: 'Peter',
 										},
-									}),
-									delete: [],
-								},
-							});
-							setTimeout(() => {
-								expect(store.get('players/1/name')).toEqual(nodeify('Peter'));
-							});
-						}, 100);
-					} else {
-						expect(data).toEqual<BatchedUpdate>({
-							change: nodeify({ name: 'Peter' }),
+									},
+								}),
+								delete: [],
+							},
 						});
-						done();
-					}
+						setTimeout(() => {
+							expect(store.get('players/1/name')).toEqual(nodeify('Peter'));
+						});
+					}, 100);
+				} else {
+					expect(data).toEqual<BatchedUpdate>({
+						change: nodeify({ name: 'Peter' }),
+					});
+					done();
 				}
-			},
-			close() {},
+			}
 		},
-		'1'
-	);
+	});
 
 	notify('subscribe', { path: 'players/1' });
 });
@@ -229,46 +169,32 @@ test('only emits changed values', (done) => {
 		})
 	);
 
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, removeListener, notify } = createEventBroker();
+	const { socketServer, connectClient } = mockSocketServer();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
 	SocketDBServer({ store, socketServer });
 
 	let updateCount = 0;
 
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off: removeListener,
-			send(event, { data }) {
-				if (event === 'players/1') {
-					if (updateCount === 0) {
-						updateCount++;
-						expect(data).toEqual({ change: nodeify({ name: 'Peter' }) });
-					} else {
-						expect(data).toEqual({
-							change: nodeify({
-								position: {
-									x: 0,
-									y: 1,
-								},
-							}),
-						});
-						done();
-					}
+	const { notify } = connectClient({
+		onSend(event, { data }) {
+			if (event === 'players/1') {
+				if (updateCount === 0) {
+					updateCount++;
+					expect(data).toEqual({ change: nodeify({ name: 'Peter' }) });
+				} else {
+					expect(data).toEqual({
+						change: nodeify({
+							position: {
+								x: 0,
+								y: 1,
+							},
+						}),
+					});
+					done();
 				}
-			},
-			close() {},
+			}
 		},
-		'1'
-	);
+	});
 
 	notify('subscribe', { path: 'players/1' });
 	notify('update', {
@@ -300,71 +226,45 @@ test('emits updates to all subscribers', async () => {
 			},
 		})
 	);
-	let connect: (client: Socket, id: string) => void;
+	const { socketServer, connectClient } = mockSocketServer();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
 	SocketDBServer({ store, socketServer });
 
 	await new Promise<void>((resolve) => {
-		const { addListener, removeListener, notify } = createEventBroker();
-		connect(
-			{
-				onDisconnect() {},
-				on: addListener,
-				off: removeListener,
-				send(event, { data }) {
-					if (event === 'players') {
-						expect(data).toEqual({
-							change: nodeify({
-								1: {
-									name: 'Peter',
-								},
-							}),
-						});
-						resolve();
-					}
-				},
-				close() {},
+		const { notify } = connectClient({
+			onSend(event, { data }) {
+				if (event === 'players') {
+					expect(data).toEqual({
+						change: nodeify({
+							1: {
+								name: 'Peter',
+							},
+						}),
+					});
+					resolve();
+				}
 			},
-			'1'
-		);
+		});
 		notify('subscribe', { path: 'players', once: true });
 	});
 	await new Promise<void>((resolve) => {
-		const { addListener, removeListener, notify } = createEventBroker();
-		connect(
-			{
-				onDisconnect() {},
-				on: addListener,
-				off: removeListener,
-				send(event, { data }) {
-					if (event === 'players/1/name') {
-						expect(data).toEqual({ change: nodeify('Peter') });
-						resolve();
-					}
-				},
-				close() {},
+		const { notify } = connectClient({
+			onSend(event, { data }) {
+				if (event === 'players/1/name') {
+					expect(data).toEqual({ change: nodeify('Peter') });
+					resolve();
+				}
 			},
-			'2'
-		);
+		});
 		notify('subscribe', { path: 'players/1/name' });
 	});
 });
 
 test('sends keys when entries are added or removed', async () => {
 	const store = createStore();
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, removeListener, notify } = createEventBroker();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
+	const { socketServer, connectClient } = mockSocketServer();
+
 	const server = SocketDBServer({ store, socketServer });
 
 	server.update(
@@ -379,76 +279,56 @@ test('sends keys when entries are added or removed', async () => {
 
 	await new Promise<void>((resolve) => {
 		let count = 0;
-		connect(
-			{
-				onDisconnect() {},
-				on: addListener,
-				off: removeListener,
-				send(event, { data }) {
-					if (event === 'players/*') {
-						if (count === 0) {
-							expect(data).toEqual(['1']);
-							setTimeout(() => {
-								notify('update', {
-									data: {
-										change: nodeify({
-											players: {
-												1: {
-													name: 'Peter',
-												},
-												2: {
-													name: 'Parker',
-												},
+		const { notify } = connectClient({
+			onSend(event, { data }) {
+				if (event === 'players/*') {
+					if (count === 0) {
+						expect(data).toEqual(['1']);
+						setTimeout(() => {
+							notify('update', {
+								data: {
+									change: nodeify({
+										players: {
+											1: {
+												name: 'Peter',
 											},
-										}),
-									},
-								});
-							}, 100);
-						}
-						if (count === 1) {
-							expect(data).toEqual(['2']);
-							resolve();
-						}
-						count++;
+											2: {
+												name: 'Parker',
+											},
+										},
+									}),
+								},
+							});
+						}, 100);
 					}
-				},
-				close() {},
+					if (count === 1) {
+						expect(data).toEqual(['2']);
+						resolve();
+					}
+					count++;
+				}
 			},
-			'1'
-		);
+		});
 		notify('subscribeKeys', { path: 'players', flat: true });
 	});
 });
 
 test('only send data if client is subscribed', (done) => {
 	const store = createStore();
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, removeListener, notify } = createEventBroker();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
+	const { socketServer, connectClient } = mockSocketServer();
+
 	const server = SocketDBServer({ store, socketServer });
 
 	let receivedCount = 0;
 
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off: removeListener,
-			send(event, { data }) {
-				if (event === 'players/1') {
-					receivedCount++;
-				}
-			},
-			close() {},
+	const { notify } = connectClient({
+		onSend(event, { data }) {
+			if (event === 'players/1') {
+				receivedCount++;
+			}
 		},
-		'1'
-	);
+	});
 
 	notify('subscribe', { path: 'players/1' });
 	notify('unsubscribe', { path: 'players/1' });
@@ -469,37 +349,24 @@ test('only send data if client is subscribed', (done) => {
 
 test('should batch updates', (done) => {
 	const store = createStore();
-	let connect: (client: Socket, id: string) => void;
-	const { addListener, removeListener, notify } = createEventBroker();
 
-	const socketServer: SocketServer = {
-		onConnection(callback) {
-			connect = callback;
-		},
-	};
+	const { socketServer, connectClient } = mockSocketServer();
+
 	SocketDBServer({ store, socketServer, updateInterval: 10 });
 
 	let receivedCount = 0;
 
-	// @ts-ignore - connect is set when the server is created above (synchronously)
-	connect(
-		{
-			onDisconnect() {},
-			on: addListener,
-			off: removeListener,
-			send(event, { data }) {
-				if (receivedCount === 0) {
-					expect(data).toEqual({ change: nodeify(null) });
-				}
-				if (receivedCount === 1) {
-					expect(data).toEqual({ change: nodeify('b'), delete: ['player/a'] });
-				}
-				receivedCount++;
-			},
-			close() {},
+	const { notify } = connectClient({
+		onSend(event, { data }) {
+			if (receivedCount === 0) {
+				expect(data).toEqual({ change: nodeify(null) });
+			}
+			if (receivedCount === 1) {
+				expect(data).toEqual({ change: nodeify('b'), delete: ['player/a'] });
+			}
+			receivedCount++;
 		},
-		'1'
-	);
+	});
 
 	notify('subscribe', { path: 'player' });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -118,7 +118,7 @@ test('emits updates to subscriber', (done) => {
 	const store = createStore();
 	const { socketServer, connectClient } = mockSocketServer();
 
-	SocketDBServer({ store, socketServer });
+	SocketDBServer({ store, socketServer, updateInterval: 5 });
 
 	let count = 1;
 	const { notify } = connectClient({
@@ -143,7 +143,7 @@ test('emits updates to subscriber', (done) => {
 						setTimeout(() => {
 							expect(store.get('players/1/name')).toEqual(nodeify('Peter'));
 						});
-					}, 100);
+					}, 25);
 				} else {
 					expect(data).toEqual<BatchedUpdate>({
 						change: nodeify({ name: 'Peter' }),
@@ -265,7 +265,7 @@ test('sends keys when entries are added or removed', async () => {
 
 	const { socketServer, connectClient } = mockSocketServer();
 
-	const server = SocketDBServer({ store, socketServer });
+	const server = SocketDBServer({ store, socketServer, updateInterval: 5 });
 
 	server.update(
 		nodeify({
@@ -299,7 +299,7 @@ test('sends keys when entries are added or removed', async () => {
 									}),
 								},
 							});
-						}, 100);
+						}, 25);
 					}
 					if (count === 1) {
 						expect(data).toEqual(['2']);
@@ -318,7 +318,7 @@ test('only send data if client is subscribed', (done) => {
 
 	const { socketServer, connectClient } = mockSocketServer();
 
-	const server = SocketDBServer({ store, socketServer });
+	const server = SocketDBServer({ store, socketServer, updateInterval: 10 });
 
 	let receivedCount = 0;
 
@@ -344,7 +344,7 @@ test('only send data if client is subscribed', (done) => {
 	setTimeout(() => {
 		expect(receivedCount).toBe(1);
 		done();
-	}, 100);
+	}, 50);
 });
 
 test('should batch updates', (done) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,125 @@
+import { createEventBroker } from '../src';
+import { GenericQueuedEvent } from '../src/batchedSocketEvents';
+import { Socket } from '../src/socketAdapter/socket';
+import { SocketClient } from '../src/socketAdapter/socketClient';
+import { SocketServer } from '../src/socketAdapter/socketServer';
+
+function createQueuedEvent(event: string, data: any) {
+	return { event, data };
+}
+
+function batched(notify: (event: string, data: any) => void) {
+	return (event: string, data: any) => {
+		notify('data', { events: [createQueuedEvent(event, data)] });
+	};
+}
+
+/**
+ * creates a mock socket server for testing
+ */
+export function mockSocketServer() {
+	let connect: (client: Socket, id: string) => void = () => {
+		throw new Error('connect not yet initialized');
+	};
+
+	const socketServer: SocketServer = {
+		onConnection(callback) {
+			connect = callback;
+		},
+	};
+
+	return {
+		connectClient: ({
+			id = generateId(),
+			onSend,
+			onClose,
+		}: {
+			id?: string;
+			onSend?: (event: string, data: any) => void;
+			onClose?: () => void;
+		} = {}) => {
+			const { disconnect, notify, socket } = mockSocket({
+				onClose,
+				onSend,
+			});
+			connect(socket, id);
+			return {
+				disconnect,
+				notify,
+			};
+		},
+		socketServer,
+	};
+}
+
+export function mockSocketClient({
+	onClose,
+	onSend,
+}: {
+	onSend?: (event: string, data: any) => void;
+	onClose?: () => void;
+} = {}) {
+	const { disconnect, notify, socket } = mockSocket({ onClose, onSend });
+	let connect: () => void = () => {
+		throw new Error('connect not yet initialized');
+	};
+
+	const socketClient: SocketClient = {
+		...socket,
+		onConnect(callback) {
+			connect = callback;
+			// simulate connection
+			setTimeout(() => {
+				callback();
+			}, 10);
+		},
+	};
+
+	return {
+		socketClient,
+		disconnect,
+		notify,
+		reconnect: () => connect(),
+	};
+}
+
+/**
+ * mocks a single socket connection that also unwraps batched events for easier testing
+ */
+function mockSocket({
+	onClose,
+	onSend,
+}: {
+	onSend?: (event: string, data: any) => void;
+	onClose?: () => void;
+} = {}) {
+	const { addListener, notify, removeListener } = createEventBroker();
+	let disconnect: () => void = () => {
+		throw new Error('disconnect not yet initialized');
+	};
+	const socket: Socket = {
+		on: addListener,
+		off: removeListener,
+		close() {
+			onClose?.();
+		},
+		onDisconnect(callback) {
+			disconnect = callback;
+		},
+		send(_, { events }: { events: GenericQueuedEvent<any>[] }) {
+			events.forEach((event) => {
+				onSend?.(event.event as string, event.data);
+			});
+		},
+	};
+
+	return {
+		socket,
+		disconnect: () => disconnect(),
+		notify: batched(notify),
+	};
+}
+
+function generateId() {
+	return Math.random().toString(36).substring(2, 15).toUpperCase();
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,7 +10,7 @@ function createQueuedEvent(event: string, data: any) {
 
 function batched(notify: (event: string, data: any) => void) {
 	return (event: string, data: any) => {
-		notify('data', { events: [createQueuedEvent(event, data)] });
+		notify('events', [createQueuedEvent(event, data)]);
 	};
 }
 
@@ -106,7 +106,7 @@ function mockSocket({
 		onDisconnect(callback) {
 			disconnect = callback;
 		},
-		send(_, { events }: { events: GenericQueuedEvent<any>[] }) {
+		send(_, events: GenericQueuedEvent<any>[]) {
 			events.forEach((event) => {
 				onSend?.(event.event as string, event.data);
 			});


### PR DESCRIPTION
With this PR, all socket events will now be batched, including "subscribe" and "unsubscribe" calls. It respects the configured update interval (see: SocketDBClient and SocketDBServer).

This makes nested subscribe calls more efficient.

Image the following code:

(Where the path `items` has 1000 child nodes.)

```ts
client.get('items').each(ref => {
  ref.on(item => {
   // do something
  });
});
```

With the current implementation, it will:
1. send a subscription request for the child nodes of "items" (event: "subscribeKeys", path: "items")
2. receive the keys of the child nodes
3. send 1000 subscription requests (1000 socket events) for each child (event: "subscribe", path: "items/x")
4. receive 1000 updates for each child (1000 socket events)

With this update it will batch all these subscribe calls, and it will behave like this:
1. send a subscription request for the child nodes of "items" (event: "subscribeKeys", path: "items")
2. receive the keys of the child nodes
3. send a single socket event that includes the 1000 subscriptions requests
4. receive a single socket event that includes all 1000 updates

=> this way we can batch all those socket events into a single one, reducing the amount of packages significantly