### PR TITLE
feat/allow initializing session context

### DIFF
--- a/apps/docs/docs/api/server.md
+++ b/apps/docs/docs/api/server.md
@@ -7,11 +7,13 @@ function SocketDBServer(config?: {
 	updateInterval?: number;
 	socketServer?: SocketServer;
 	plugins?: ServerPlugin[];
+	autoListen?: boolean;
 }): SocketDB;
 
 type SocketDB = {
 	update: (data: Node) => void;
 	get: (path: string) => Node;
 	delete: (path: string) => void;
+	listen: (port?: number, callback?: () => void) => void;
 };
 ```

--- a/apps/docs/docs/guide/authentication.md
+++ b/apps/docs/docs/guide/authentication.md
@@ -1,0 +1,84 @@
+# Authentication
+
+To add authentication to socketdb, you can pass a `initializeSession` function to the `createWebsocketServer` function. This also allows you to pass custom user data to plugins.
+
+```ts
+const socketServer = createWebsocketServer({
+	initializeSession: async ({ req }) => {
+		try {
+			const session = await getSession(req);
+			// fill context with user data
+			return {
+				user: session.user,
+			};
+		} catch (error) {
+			// this will close the connection
+			throw new WebsocketServerError({
+				code: 'UNAUTHORIZED',
+			});
+		}
+	},
+});
+```
+
+Plugins then have access to the context object.
+
+```ts
+const server = SocketDBServer({
+	socketServer,
+	plugins: [
+		{
+			name: 'example-plugin',
+			hooks: {
+				'server:update': async (data, { client }) => {
+					console.log(client.context); // { user: { id: 1 } }
+				},
+			},
+		},
+	],
+});
+```
+
+## Using with typescript
+
+When using typescript, you can override the type of the context object. For example:
+
+```ts
+declare module '@socketdb/server' {
+	interface SessionContext {
+		user: {
+			id: string;
+		};
+	}
+}
+```
+
+## Example for a jwt token authentication
+
+This authentication example uses a jwt token to authenticate the user. The token is passed as a query parameter.
+
+```ts
+import { createWebsocketServer } from '@socketdb/server';
+import jwt from 'jsonwebtoken';
+import { parseUrl } from 'query-string';
+
+const CLIENT_SECRET = process.env.CLIENT_SECRET;
+
+const socketServer = createWebsocketServer({
+	initializeSession: async ({ req }) => {
+		// get token from query, e.g. ws://localhost:8080?token=...
+		const { token } = parseUrl(req.url ?? '').query as { token: string };
+		if (!token) throw new WebsocketServerError({ code: 'BAD_REQUEST' });
+		try {
+			const decoded = jwt.verify(token, CLIENT_SECRET);
+			return {
+				user: decoded,
+			};
+		} catch (error) {
+			throw new WebsocketServerError({
+				code: 'UNAUTHORIZED',
+			});
+		}
+	},
+});
+```

--- a/apps/docs/docs/guide/custom-server-implementation.md
+++ b/apps/docs/docs/guide/custom-server-implementation.md
@@ -1,7 +1,11 @@
 # Custom Websocket-Server Implementation
 
+:::info
+This is an advanced feature. In most cases you don't need to use this.
+:::
+
 SocketDB allows you to pass a custom websocket server implementation.
-This is useful if you want to use a different websocket server implementation than the one provided by SocketDB or if you want to add authentication / authorization or user session information to your SocketDB instance.
+This is useful if you want to use a different websocket server implementation than the one provided by SocketDB. Or if you want to use a different connection protocol, like HTTP instead of Websockets.
 
 By default SocketDB uses [ws](https://github.com/websockets/ws) as websocket server implementation.
 
@@ -10,7 +14,7 @@ By default SocketDB uses [ws](https://github.com/websockets/ws) as websocket ser
 ```ts
 import { createEventBroker, SocketServer } from '@socketdb/core';
 
-export const createMyCustomWebsocketServer = (): SocketServer => {
+export function createMyCustomWebsocketServer(): SocketServer {
 	let ids = 0;
 	const server = MyWebsocketServerImplementation.create();
 
@@ -47,23 +51,15 @@ export const createMyCustomWebsocketServer = (): SocketServer => {
 				);
 			});
 		},
+		listen(port, callback) {
+			server.listen(port, callback);
+		},
 	};
-};
+}
 ```
 
 ```js
 const server = SocketDBServer({
 	socketServer: createMyCustomWebsocketServer(),
-	plugins: [
-		{
-			name: 'log-user-data',
-			hooks: {
-				'server:clientConnect': (_, { client }) => {
-					console.log(client.context);
-					done();
-				},
-			},
-		},
-	],
 });
 ```

--- a/apps/docs/docs/guide/migration-guides/v5-to-v6.mdx
+++ b/apps/docs/docs/guide/migration-guides/v5-to-v6.mdx
@@ -1,0 +1,50 @@
+# v6 Migration Guide
+
+## This update changes the api of the `createWebsocketServer` function
+
+:::info
+This change only affects you if you are using the `createWebsocketServer` function directly or a custom implementation of it.
+:::
+
+An `initializeSession` function has been added as option. If you have been using the `verifyClient` option from ws to initialize the session, it is now recommended to use this function instead. For example:
+
+```diff
+const server = createWebsocketServer({
+-	async verifyClient(info, done) {
+-		const result = validateUserToken(info.req);
+-		if (result.ok) {
+-			return done(true);
+-		} else {
+-			done(false, 403, 'Forbidden');
+-		}
+-	},
++	async initializeSession({ req }) {
++		const result = validateUserToken(req);
++		if (result.ok) {
++			return {
++				// userid: result.userid,
++			};
++		} else {
++			throw new WebsocketServerError({
++				code: 'FORBIDDEN',
++			});
++		}
++	},
+});
+```
+
+`createWebsocketServer` now also returns a `listen` function that requires a `port` argument.
+The `listen` function will be run by the SocketDBServer, you don't need to call it yourself.
+
+```diff
+type SocketServer = {
+	onConnection: (
+		callback: (
+			client: Socket,
+			id: string,
+			sessionContext?: SessionContext
+		) => void
+	) => void;
++ listen: (port: number, callback?: () => void) => void;
+};
+```

--- a/apps/docs/docs/guide/quick-start.mdx
+++ b/apps/docs/docs/guide/quick-start.mdx
@@ -15,7 +15,7 @@ Create `index.js` file with:
 ```js
 import { SocketDBServer } from '@socketdb/server';
 
-SocketDBServer({ port: 8080 });
+SocketDBServer().listen(8080);
 ```
 
 Run it with `node index.js`.

--- a/apps/docs/docs/guide/server.md
+++ b/apps/docs/docs/guide/server.md
@@ -29,11 +29,14 @@ import { SocketDBServer, createWebsocketServer } from '@socketdb/server';
 import { createServer } from 'http';
 import express from 'express';
 const app = express();
-const server = createServer(app).listen(8080);
+const server = createServer(app);
 
 SocketDBServer({
 	socketServer: createWebsocketServer({ server }),
+	autoListen: false,
 });
+
+server.listen(8080);
 ```
 
 ## get

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -37,7 +37,7 @@ const sidebars = {
 		{
 			type: 'category',
 			label: 'Advanced',
-			items: ['guide/persistence'],
+			items: ['guide/persistence', 'guide/authentication'],
 		},
 		{
 			type: 'category',
@@ -45,6 +45,7 @@ const sidebars = {
 			items: [
 				'guide/migration-guides/v3-to-v4',
 				'guide/migration-guides/v4-to-v5',
+				'guide/migration-guides/v5-to-v6',
 			],
 		},
 	],

--- a/packages/core/src/lib/socket-connection/socketServer.ts
+++ b/packages/core/src/lib/socket-connection/socketServer.ts
@@ -1,6 +1,6 @@
 import { Socket } from './socket';
 
-export type SessionContext = Record<string, unknown>;
+type SessionContext = Record<string, unknown>;
 
 export type SocketServer = {
 	onConnection: (
@@ -10,4 +10,5 @@ export type SocketServer = {
 			sessionContext?: SessionContext
 		) => void
 	) => void;
+	listen: (port: number, callback?: () => void) => void;
 };

--- a/packages/integration-tests/src/tests/integration.spec.ts
+++ b/packages/integration-tests/src/tests/integration.spec.ts
@@ -264,6 +264,7 @@ test('should batch all socket events', (done) => {
 		onConnection(callback) {
 			connect = callback;
 		},
+		listen() {},
 	};
 	SocketDBServer({ socketServer, updateInterval: 10, store });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,9 @@
 export { SocketDBServer } from './lib/server';
-export type { ServerPlugin, SocketDBServerAPI } from './lib/server';
+export type {
+	ServerPlugin,
+	SessionContext,
+	SocketDBServerAPI,
+} from './lib/server';
+export { WebsocketServerError } from './lib/socket-implementation/httpUpgradeError';
 export { mockSocketServer } from './lib/socket-implementation/mockServer';
 export { createWebsocketServer } from './lib/socket-implementation/websocketServer';

--- a/packages/server/src/lib/server.plugins.spec.ts
+++ b/packages/server/src/lib/server.plugins.spec.ts
@@ -8,6 +8,7 @@ test('allows providing hooks via plugins', (done) => {
 	const server = SocketDBServer({
 		store,
 		socketServer: {
+			listen() {},
 			onConnection() {},
 		},
 		plugins: [

--- a/packages/server/src/lib/server.spec.ts
+++ b/packages/server/src/lib/server.spec.ts
@@ -14,6 +14,7 @@ test('updates data on manual update', () => {
 	const server = SocketDBServer({
 		store,
 		socketServer: {
+			listen() {},
 			onConnection() {},
 		},
 	});
@@ -415,6 +416,7 @@ test('allows adding a custom user context', (done) => {
 					{ username: 'Peter' }
 				);
 			},
+			listen() {},
 		},
 		plugins: [
 			{

--- a/packages/server/src/lib/socket-implementation/httpUpgradeError.ts
+++ b/packages/server/src/lib/socket-implementation/httpUpgradeError.ts
@@ -1,0 +1,41 @@
+const ERROR_CODES = {
+	BAD_REQUEST: {
+		code: 400,
+		message: 'Bad Request',
+	},
+	UNAUTHORIZED: {
+		code: 401,
+		message: 'Unauthorized',
+	},
+	FORBIDDEN: {
+		code: 403,
+		message: 'Forbidden',
+	},
+	NOT_FOUND: {
+		code: 404,
+		message: 'Not Found',
+	},
+	INTERNAL_SERVER_ERROR: {
+		code: 500,
+		message: 'Internal Server Error',
+	},
+};
+
+type ErrorCode = keyof typeof ERROR_CODES;
+
+export class WebsocketServerError extends Error {
+	public readonly code;
+
+	constructor(opts: { code: ErrorCode }) {
+		const errorType =
+			ERROR_CODES[opts.code] || ERROR_CODES.INTERNAL_SERVER_ERROR;
+		super(errorType.message);
+		this.code = opts.code;
+		this.name = 'SocketDBServerError';
+	}
+}
+
+export function createHttpResponse(code: ErrorCode) {
+	const errorType = ERROR_CODES[code] || ERROR_CODES.INTERNAL_SERVER_ERROR;
+	return `HTTP/1.1 ${errorType.code} ${errorType.message}\r\n\r\n`;
+}

--- a/packages/server/src/lib/socket-implementation/incrementalIdGenerator.ts
+++ b/packages/server/src/lib/socket-implementation/incrementalIdGenerator.ts
@@ -1,0 +1,4 @@
+export function createIncrementalIdGenerator() {
+	let id = 0;
+	return () => id++ + '';
+}

--- a/packages/server/src/lib/socket-implementation/mockServer.ts
+++ b/packages/server/src/lib/socket-implementation/mockServer.ts
@@ -12,6 +12,9 @@ export function mockSocketServer() {
 		onConnection(callback) {
 			connect = callback;
 		},
+		listen() {
+			// no-op
+		},
 	};
 
 	return {

--- a/packages/server/src/lib/socket-implementation/websocketServer.ts
+++ b/packages/server/src/lib/socket-implementation/websocketServer.ts
@@ -1,45 +1,96 @@
 import { createEventBroker, SocketServer } from '@socketdb/core';
+import { createServer, IncomingMessage } from 'http';
 import ws from 'ws';
+import { SessionContext } from '../server';
+import { createHttpResponse, WebsocketServerError } from './httpUpgradeError';
+import { createIncrementalIdGenerator } from './incrementalIdGenerator';
 
-export const createWebsocketServer = (
-	options: ws.ServerOptions
-): SocketServer => {
-	let ids = 0;
-	const server = new ws.Server(options);
+/**
+ * options that are passed to the ws.Server constructor
+ */
+type CustomizableWSOptions = Omit<ws.ServerOptions, 'noServer' | 'port'>;
+
+export const createWebsocketServer = ({
+	initializeSession,
+	generateId = createIncrementalIdGenerator(),
+	server: httpServer = createServer(),
+	...wsOptions
+}: {
+	/**
+	 * A returned session context will be available in plugins.
+	 * You can use this to authenticate a user and  pass additional user data to plugins, e.g. an external user id.
+	 *
+	 * You can throw a `WebsocketServerError` to reject the connection with a specific error code.
+	 */
+	initializeSession?: (params: {
+		req: IncomingMessage;
+	}) => SessionContext | Promise<SessionContext>;
+	/**
+	 * Id generation function. Defaults to an incremental id generator.
+	 */
+	generateId?: () => string;
+} & CustomizableWSOptions = {}): SocketServer => {
+	const wsServer = new ws.Server({
+		...wsOptions,
+		noServer: true,
+		port: undefined,
+	});
 
 	return {
 		onConnection(callback) {
-			server.on('connection', (socket) => {
-				const { notify, addListener, removeListener } = createEventBroker();
+			httpServer.on('upgrade', async (request, socket, head) => {
+				let sessionContext: SessionContext | undefined;
+				if (initializeSession) {
+					try {
+						sessionContext = await initializeSession({ req: request });
+					} catch (error) {
+						if (error instanceof WebsocketServerError) {
+							socket.write(createHttpResponse(error.code));
+							socket.destroy();
+							return;
+						}
+						socket.write(createHttpResponse('INTERNAL_SERVER_ERROR'));
+						socket.destroy();
+						return;
+					}
+				}
 
-				socket.on('message', (packet) => {
-					const message =
-						typeof packet === 'string' ? packet : packet.toString();
-					const { event, data } = JSON.parse(message);
-					notify(event, data);
+				wsServer.handleUpgrade(request, socket, head, (client) => {
+					const { notify, addListener, removeListener } = createEventBroker();
+
+					client.on('message', (packet) => {
+						const message =
+							typeof packet === 'string' ? packet : packet.toString();
+						const { event, data } = JSON.parse(message);
+						notify(event, data);
+					});
+
+					callback(
+						{
+							onDisconnect(callback) {
+								client.on('close', callback);
+							},
+							on: addListener,
+							off: removeListener,
+							send(event, data) {
+								try {
+									client.send(JSON.stringify({ event, data }));
+								} catch (error) {
+									console.error(error);
+								}
+							},
+							close() {
+								client.close();
+							},
+						},
+						generateId(),
+						sessionContext
+					);
 				});
-
-				callback(
-					{
-						onDisconnect(callback) {
-							socket.on('close', callback);
-						},
-						on: addListener,
-						off: removeListener,
-						send(event, data) {
-							try {
-								socket.send(JSON.stringify({ event, data }));
-							} catch (error) {
-								console.error(error);
-							}
-						},
-						close() {
-							socket.close();
-						},
-					},
-					ids++ + ''
-				);
 			});
+		},
+		listen(port, callback) {
+			httpServer.listen(port, callback);
 		},
 	};
 };


### PR DESCRIPTION
This pr adds a new api for creating a user session context. This also allows you to intercept the http upgrade to, for example, add authentication or verify requests.

It introduces a few breaking changes when using a custom websocket-server.

It also adds a `listen` method to the SocketDBServer. 
Starting the server will probably be changed to require a `listen(port)` call in the future.

Todos:
- [x] add a way to customize the http error response
- [x] update documentation